### PR TITLE
added Name component for easier debugging with world inspector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 crossbeam-channel = "0.5.7"
+
+[dev-dependencies]
+bevy-inspector-egui = "0.21.0"
+bevy = {version = "0.12.0", features = ["multi-threaded"]}

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -1,0 +1,55 @@
+use bevy::prelude::*;
+use bevy::time::common_conditions::on_timer;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_mod_reqwest::*;
+use std::time::Duration;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            WorldInspectorPlugin::default(),
+            ReqwestPlugin,
+        ))
+        .add_systems(Startup, send_ignored_request)
+        .add_systems(
+            Update,
+            (
+                send_requests.run_if(on_timer(Duration::from_secs(2))),
+                handle_responses.run_if(on_timer(Duration::from_secs(1))),
+            ),
+        )
+        .run();
+}
+
+#[derive(Component)]
+struct Ignore;
+
+fn send_ignored_request(mut commands: Commands) {
+    let Ok(url) = "https://www.boredapi.com/api".try_into() else {
+        return;
+    };
+
+    let req = reqwest::Request::new(reqwest::Method::GET, url);
+    let req = ReqwestRequest::new(req);
+    commands.spawn((req, Ignore));
+}
+
+fn send_requests(mut commands: Commands) {
+    let Ok(url) = "https://www.boredapi.com/api".try_into() else {
+        return;
+    };
+
+    let req = reqwest::Request::new(reqwest::Method::GET, url);
+    let req = ReqwestRequest::new(req);
+    commands.spawn(req);
+}
+
+fn handle_responses(
+    mut commands: Commands,
+    results: Query<Entity, (Without<Ignore>, With<ReqwestBytesResult>)>,
+) {
+    for e in results.iter() {
+        commands.entity(e).despawn_recursive();
+    }
+}


### PR DESCRIPTION
Added the `Name` component to new `ReqwestRequest`s without one and a quick example showcasing it.

This makes debugging with [`bevy-inspector-egui`](https://github.com/jakobhellermann/bevy-inspector-egui) a lot easier

![image](https://github.com/TotalKrill/bevy_mod_reqwest/assets/17007091/5e93688b-c10b-4156-a300-efdc477c8bd7)
