### PR TITLE
fix building on arm based chips

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ crossbeam-channel = "0.5.7"
 # bevy-inspector-egui = {version = "0.23", git = "https://github.com/Aztro-dev/bevy-inspector-egui.git" }
 bevy = {version = "0.13.0", features = ["multi-threaded"]}
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-compat = "0.2.1"


### PR DESCRIPTION
closes #9 

I use the same `cfg` we use inside the code to choose whehter to use async_compat instead of the chipset now