### PR TITLE
Use consuming callback builders in BevyReqwestBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,9 @@ impl<'a> BevyReqwestBuilder<'a> {
     /// };
     /// ```
     pub fn on_response<RB: Bundle, RM, OR: IntoObserverSystem<ReqwestResponseEvent, RB, RM>>(
-        &mut self,
+        mut self,
         onresponse: OR,
-    ) -> &mut Self {
+    ) -> Self {
         self.0.observe(onresponse);
         self
     }
@@ -164,9 +164,9 @@ impl<'a> BevyReqwestBuilder<'a> {
         RM,
         OR: IntoObserverSystem<json::JsonResponse<T>, RB, RM>,
     >(
-        &mut self,
+        mut self,
         onresponse: OR,
-    ) -> &mut Self {
+    ) -> Self {
         self.0.observe(
             |evt: Trigger<ReqwestResponseEvent>, mut commands: Commands| {
                 let entity = evt.entity();
@@ -205,9 +205,9 @@ impl<'a> BevyReqwestBuilder<'a> {
     /// };
     /// ```
     pub fn on_error<EB: Bundle, EM, OE: IntoObserverSystem<ReqwestErrorEvent, EB, EM>>(
-        &mut self,
+        mut self,
         onerror: OE,
-    ) -> &mut Self {
+    ) -> Self {
         self.0.observe(onerror);
         self
     }


### PR DESCRIPTION
This change allows this sort of usage:

```
fn thing<'a>(client: &'a mut BevyReqwest) -> BevyReqwestBuilder<'a> {
    [...]

    let req = client
        .post(url)
        .json(...)
        .build()
        .unwrap();

    client
        .send(req)
        .on_response(|trigger: Trigger<ReqwestResponseEvent>| info!("got a response"))
}

fn heartbeat(client: &mut BevyReqwest) {
    thing(client)
    .on_error(|trigger: Trigger<ReqwestErrorEvent>| {
        let e = &trigger.event().0;
        error!("heartbeat error: {:?}", e);
    });
}
```